### PR TITLE
Sort unknown containers to the back

### DIFF
--- a/i3l/state.py
+++ b/i3l/state.py
@@ -99,7 +99,8 @@ class Context:
         return len(containers) > 0
 
     def sorted_containers(self) -> List[Con]:
-        return sorted(self.containers, key=lambda container: self.workspace_sequence.get_order(container.id))
+        n = len(self.containers)
+        return sorted(self.containers, key=lambda container: self.workspace_sequence.get_order(container.id) or n)
 
     def workspace_width(self, ratio: float = 1.0) -> int:
         return int(self.workspace.rect.width * ratio)


### PR DESCRIPTION
If external monitors are repeatedly connected and disconnected, a state could arise where some containers are not in the workspace sequence and `get_order` returns `None`. This would raise an exception, so we sort these containers to the back in that case.